### PR TITLE
added blackbox exporter, enable GitLab metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 - [ ] Grafana
     - [ ] Create Sample dashboard with repo monitoring
     - [ ] Create Sample dashboard with CI/CD monitoring
-- [ ] Prometheus
-    - [ ] Add rules for neccesery metrics for GitLab, Registry, etc.
+- [ X ] Prometheus
+    - [ X ] Add rules for neccesery metrics for GitLab, Registry, etc.
 - [ ] Nginx
     - [ ] Use Nginx as proxy server for GitLab and Grafana
 

--- a/blackbox/config-blackbox.yml
+++ b/blackbox/config-blackbox.yml
@@ -1,0 +1,8 @@
+modules:
+  http_2xx:
+    prober: http
+    timeout: 5s
+    http:
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      follow_redirects: true
+      preferred_ip_protocol: "ip4"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,38 @@ services:
       - "443:443" #HTTPS
       - "22:22" #SSH
       - "80:80" #Browser
+      - "5000:5000" #Registry
     environment:
       GITLAB_OMNIBUS_CONFIG: |
         external_url 'http://gitlab'
         prometheus['enable'] = false
 
         gitlab_rails['monitoring_whitelist'] = ['172.0.0.0/8', '192.168.0.1']
+        gitlab_rails['prometheus_address'] = '0.0.0.0:9090'
+      
+        gitlab_exporter['enable'] = true
+        gitlab_exporter['listen_address'] = '0.0.0.0'
+        gitlab_exporter['listen_port'] = '9168'
 
+        node_exporter['enable'] = false
+
+        gitlab_workhorse['prometheus_listen_addr'] = '0.0.0.0:9229'
+
+        sidekiq['metrics_enabled'] = true
+        sidekiq['exporter_log_enabled'] = true
+        sidekiq['enable'] = true
+        sidekiq['listen_address'] = '0.0.0.0'
+
+        redis_exporter['listen_address'] = '0.0.0.0:9121'
+
+        postgres_exporter['listen_address'] = '0.0.0.0:9187'
+
+        gitaly['configuration'] = {
+          prometheus_listen_addr: '0.0.0.0:9236',
+        }
+
+        pgbouncer_exporter['listen_address'] = '0.0.0.0:9188'
+        
     volumes:
       - $GITLAB_HOME/config:/etc/gitlab
       - $GITLAB_HOME/logs:/var/log/gitlab
@@ -112,8 +137,21 @@ services:
       - "--path.sysfs=/host/sys"
       - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
     networks:
-      - configuration_network  
-
+      - configuration_network 
+  
+  # Blackbox, service used to send probes to specified services to check services endpoints
+  blackbox:
+    image: bitnami/blackbox-exporter:0.25.0
+    container_name: blackbox_exporter
+    ports:
+      - "9115:9115"
+    volumes:
+      - ./blackbox/config-blackbox.yml:/etc/blackboxexporter/config.yml
+    command: 
+      - "--config.file=/etc/blackboxexporter/config.yml"
+    networks:
+      - configuration_network
+      
   # Prometheus Server, tool for gathering metrics from services
   Prometheus_Server: 
     image: bitnami/prometheus:2.53.1
@@ -135,3 +173,4 @@ networks:
   configuration_network:
     name: gitlab_network
     driver: bridge
+  

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -8,6 +8,36 @@ scrape_configs:
     static_configs:
       - targets: ["gitlab:80"]
 
+  - job_name: "gitlab_redis"
+    static_configs:
+      - targets: ["gitlab:9121"]
+
+  - job_name: "gitlab_postgres"
+    static_configs:
+      - targets: ["gitlab:9187"]
+
+  - job_name: "gitlab_workhorse"
+    static_configs:
+      - targets: ["gitlab:9229"]
+
+  - job_name: gitlab_sidekiq
+    static_configs:
+      - targets: ["gitlab:8082"]
+
+  - job_name: gitlab_exporter_database
+    metrics_path: "/database"
+    static_configs:
+      - targets: ["gitlab:9168"]
+
+  - job_name: gitlab_exporter_sidekiq
+    metrics_path: "/sidekiq"
+    static_configs:
+      - targets: ["gitlab:9168"]
+
+  - job_name: gitlab_gitaly
+    static_configs:
+      - targets: ["gitlab:9236"]
+
   - job_name: 'cadvisor_exporter'
     static_configs:
     - targets: ['cadvisor_exporter:8080']
@@ -19,3 +49,17 @@ scrape_configs:
   - job_name: 'gitlab_ci_pipeline_exporter'
     static_configs:
       - targets: ['gitlab_ci_pipeline_exporter:8080']
+
+  - job_name: 'blackbox_exporter'
+    metrics_path: "/probe"
+    params:
+      module: ["http_2xx"]
+    static_configs:
+      - targets: ["gitlab:80", "cadvisor_exporter:8080"]
+    relabel_configs:
+        - source_labels: [__address__]
+          target_label: __param_target
+        - source_labels: [__param_target]
+          target_label: instance
+        - target_label: __address__
+          replacement: blackbox:9115


### PR DESCRIPTION
Added following features:
- Blackbox service
- Created simple configuration for Blackbox
- Enable multiple metrics related to GitLab
- Monitor metrics and services in Prometheus